### PR TITLE
enable django log capture in gunicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD (unreleased)
+
+- Fixing log generation with gunicorn.
+
 ## v0.3.0
 
 - Force-disabling sentry integration.

--- a/templates/sodar-core-app-web.gunicorn.service.j2
+++ b/templates/sodar-core-app-web.gunicorn.service.j2
@@ -26,7 +26,9 @@ ExecStart=/srv/{{ sodar_core_app_name }}-web/{{ sodar_core_app_version }}-venv/b
           --pid=/var/run/{{ sodar_core_app_name }}/{{ sodar_core_app_name }}-web.pid \
           --pythonpath=/srv/{{ sodar_core_app_name }}-web/{{ sodar_core_app_version }} \
           --error-logfile=/var/log/{{ sodar_core_app_name }}/{{ sodar_core_app_name }}-web.error \
-          --daemon
+          --daemon \
+          --capture-output \
+          --enable-stdio-inheritance
 
 [Install]
 # When should this service be triggered? (this is the equivalent of SysV's runlevel 3)


### PR DESCRIPTION
This will add django console logging to the gunicorn logs we store.